### PR TITLE
Plugins update

### DIFF
--- a/WordPress/Plugins.php
+++ b/WordPress/Plugins.php
@@ -26,6 +26,18 @@ class Plugins
     }
     
     
+    /**
+     * Retrieve a plugin's ID for its file path (relative to the plugins directory)
+     *
+     * @param string $relativePath Path to plugin file, relative to the plugins directory
+     * @return string
+     */
+    final public static function ExtractID( string $relativePath )
+    {
+        return explode( '/', $relativePath )[ 0 ];
+    }
+    
+    
     /***************************************************************************
     *                                   MAIN
     ***************************************************************************/

--- a/WordPress/Plugins/Models.php
+++ b/WordPress/Plugins/Models.php
@@ -16,21 +16,6 @@ class Models
      */
     final public static function Create( string $relativePath, array $pluginData )
     {
-        // Optional variables
-        $authorURL = '';
-        if ( array_key_exists( 'AuthorURI', $pluginData )) {
-            $authorURL = $pluginData[ 'AuthorURI' ];
-        }
-        
-        // Create new Plugin instance and return
-        return new Models\Plugin(
-            $relativePath,
-            $pluginData[ 'Network' ],
-            $pluginData[ 'Version' ],
-            $pluginData[ 'Name' ],
-            $pluginData[ 'Description' ],
-            $pluginData[ 'Author' ],
-            $authorURL
-        );
+        return new Models\Plugin( $relativePath, $pluginData );
     }
 }

--- a/WordPress/Plugins/Models/Plugin.php
+++ b/WordPress/Plugins/Models/Plugin.php
@@ -9,117 +9,34 @@ use WordPress\Sites;
 class Plugin extends _Plugin
 {
     
-    /**
-     * Name of the plugin's author
-     *
-     * @var string
-     */
-    private $authorName;
-    
-    /**
-     * Link to the author's website
-     *
-     * @var string
-     */
-    private $authorURL;
-    
-    /**
-     * Description of the plugin's purpose
-     *
-     * @var string
-     */
-    private $description;
-    
-    /**
-     * User-friendly name for the plugin
-     *
-     * @var string
-     */
-    private $name;
-    
-    /**
-    * Path to plugin file, relative to the plugins directory
-    *
-    * @var string
-    */
-    private $relativePath;
-    
-    /**
-    * Indicates this plugin requires global activation on all sites
-    *
-    * @var string
-    */
-    private $requiresGlobalActivation;
-    
-    /**
-     * Plugin version number
-     *
-     * @var string
-     */
-    private $version;
-    
-    
-    /**
-     * Instantiate a new Plugin instance
-     *
-     * @param string $relativePath Path to plugin file, relative to the plugins directory
-     * @param bool   $requiresGlobalActivation Indicates this plugin requires global activation on all sites
-     * @param string $version      Plugin version number
-     * @param string $name         User-friendly name for the plugin
-     * @param string $description  Description of the plugin's purpose
-     * @param string $authorName   Name of the plugin's author
-     * @param string $authorURL    Link to the author's website
-     */
-    final public function __construct( string $relativePath,
-                                       bool   $requiresGlobalActivation,
-                                       string $version,
-                                       string $name,
-                                       string $description,
-                                       string $authorName,
-                                       string $authorURL )
-    {
-        $this->relativePath             = $relativePath;
-        $this->requiresGlobalActivation = $requiresGlobalActivation;
-        $this->version                  = $version;
-        $this->name                     = $name;
-        $this->description              = $description;
-        $this->authorName               = $authorName;
-        $this->authorURL                = $authorURL;
-    }
-    
     final public function getAuthorName()
     {
-        return $this->authorName;
+        return $this->get( 'Author', '' );
     }
     
     final public function getAuthorURL()
     {
-        return $this->authorURL;
+        return $this->get( 'AuthorURI', '' );
     }
     
     final public function getDescription()
     {
-        return $this->description;
+        return $this->get( 'Description', '' );
     }
     
     final public function getName()
     {
-        return $this->name;
-    }
-    
-    final public function getRelativePath()
-    {
-        return $this->relativePath;
+        return $this->get( 'Name', '' );
     }
     
     final public function getVersion()
     {
-        return $this->version;
+        return $this->get( 'Version', '' );
     }
     
     final public function requiresGlobalActivation()
     {
-        return $this->requiresGlobalActivation;
+        return $this->get( 'Network', false );
     }
     
     

--- a/WordPress/Plugins/Models/_Plugin.php
+++ b/WordPress/Plugins/Models/_Plugin.php
@@ -4,7 +4,7 @@ namespace WordPress\Plugins\Models;
 /**
  * Defines the structure for a single plugin
  */
-abstract class _Plugin
+abstract class _Plugin extends \WordPress\Shared\_Model
 {
     /**
      * The unique identifier for this plugin

--- a/WordPress/Plugins/Models/_Plugin.php
+++ b/WordPress/Plugins/Models/_Plugin.php
@@ -6,6 +6,39 @@ namespace WordPress\Plugins\Models;
  */
 abstract class _Plugin
 {
+    /**
+     * The unique identifier for this plugin
+     *
+     * @var string
+     */
+    private $id;
+    
+    /**
+     * Mapped array of arbitrary properties
+     *
+     * @var array
+     */
+    private $properties;
+    
+    /**
+     * Path to plugin file, relative to the plugins directory
+     *
+     * @var string
+     */
+    private $relativePath;
+    
+    /**
+     * Create a new plugin instance
+     *
+     * @param array $properties Mapped array of this plugin's properties
+     */
+    final public function __construct( string $relativePath, array $properties )
+    {
+        $this->id           = self::extractID( $relativePath );
+        $this->relativePath = $relativePath;
+        $this->properties   = $properties;
+    }
+    
     
     /***************************************************************************
     *                                  PROPERTIES
@@ -18,8 +51,41 @@ abstract class _Plugin
      */
     final public function getID()
     {
-        return self::extractID( $this->getRelativePath() );
+        return $this->id;
     }
+    
+    
+    /**
+    * Retrieves the path to this plugin's file, relative to the plugins directory
+    *
+    * @return string
+    */
+    final public function getRelativePath()
+    {
+        return $this->relativePath;
+    }
+    
+    
+    /**
+     * Retrieve a property for this plugin
+     *
+     * @param string $key          The property key
+     * @param mixed  $defaultValue The property's default value
+     * @return mixed The property value
+     */
+    final public function get( string $key, $defaultValue = '' )
+    {
+        $value = $defaultValue;
+        if ( array_key_exists( $key, $this->properties )) {
+            $value = $this->properties[ $key ];
+        }
+        return $value;
+    }
+    
+    
+    /***************************************************************************
+    *                                  ABSTRACT
+    ***************************************************************************/
     
     /**
      * Retrieves this plugin's author name
@@ -48,13 +114,6 @@ abstract class _Plugin
      * @return string
      */
     abstract public function getName();
-    
-    /**
-    * Retrieves the path to this plugin's file, relative to the plugins directory
-    *
-    * @return string
-    */
-    abstract public function getRelativePath();
     
     /**
      * Retrieves this plugin's version number

--- a/WordPress/Plugins/Models/_Plugin.php
+++ b/WordPress/Plugins/Models/_Plugin.php
@@ -6,6 +6,7 @@ namespace WordPress\Plugins\Models;
  */
 abstract class _Plugin extends \WordPress\Shared\_Model
 {
+    
     /**
      * The unique identifier for this plugin
      *
@@ -27,6 +28,7 @@ abstract class _Plugin extends \WordPress\Shared\_Model
      */
     private $relativePath;
     
+    
     /**
      * Create a new plugin instance
      *
@@ -34,7 +36,7 @@ abstract class _Plugin extends \WordPress\Shared\_Model
      */
     final public function __construct( string $relativePath, array $properties )
     {
-        $this->id           = self::extractID( $relativePath );
+        $this->id           = \WordPress\Plugins::ExtractID( $relativePath );
         $this->relativePath = $relativePath;
         $this->properties   = $properties;
     }
@@ -161,21 +163,4 @@ abstract class _Plugin extends \WordPress\Shared\_Model
      * @return bool
      */
     abstract public function isActive();
-    
-    
-    /***************************************************************************
-    *                                 UTILITIES
-    ***************************************************************************/
-    
-    
-    /**
-     * Retrieve a plugin's ID for its file path (relative to the plugins directory)
-     *
-     * @param string $relativePath Path to plugin file, relative to the plugins directory
-     * @return string
-     */
-    final protected static function extractID( string $relativePath )
-    {
-        return explode( '/', $relativePath )[ 0 ];
-    }
 }

--- a/WordPress/Shared/interfaces/_Model.php
+++ b/WordPress/Shared/interfaces/_Model.php
@@ -1,0 +1,18 @@
+<?php
+namespace WordPress\Shared;
+
+/**
+ * Defines the basic structure for a Model
+ */
+abstract class _Model
+{
+    
+    /**
+     * Retrieve a property
+     *
+     * @param string $key          The property key
+     * @param mixed  $defaultValue The property's default value
+     * @return mixed The property value
+     */
+    abstract public function get( string $key, $defaultValue = null );
+}

--- a/WordPress/Sites/Models/_Site.php
+++ b/WordPress/Sites/Models/_Site.php
@@ -6,7 +6,7 @@ use \WordPress\Sites;
 /**
  * Defines the basic structure for a Site model
  */
-abstract class _Site
+abstract class _Site extends \WordPress\Shared\_Model
 {
     
     /***************************************************************************

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,10 @@
         ],
         "psr-4": {
             "WordPress\\": [
-                "WordPress",
-                "WordPress/libraries"
+                "WordPress"
+            ],
+            "WordPress\\Shared\\": [
+                "WordPress/Shared/interfaces"
             ]
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name":        "evanwashkow/object-oriented-wordpress",
     "description": "Access all of WordPress in an object-oriented way",
-    "version":     "0.2.0",
+    "version":     "0.2.1",
     "autoload": {
         "classmap": [
             "WordPress.php"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "662f4357b85b61df1491da33c93abfa4",
+    "content-hash": "28004cd4b70cde2be0b61ff214b90f8b",
     "packages": [
         {
             "name": "evanwashkow/php-libraries",


### PR DESCRIPTION
Adds:

1. `\WordPress\Plugins::ExtractID()`, where you pass it the plugin's relative file path to get the id for that plugin

2. Generic `\WordPress\Plugins\Models\Plugin->get()` method to retrieve arbitrary properties from the plugin

3. `\WordPress\Shared\Models`: defines a basic structure for all models